### PR TITLE
Task 4: 詳細画面への「検索画面に戻る」ボタンを実装

### DIFF
--- a/frontend/src/components/EmployeeDetails.tsx
+++ b/frontend/src/components/EmployeeDetails.tsx
@@ -1,7 +1,9 @@
 import PersonIcon from "@mui/icons-material/Person";
-import { Avatar, Box, Paper, Tab, Tabs, Typography } from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import { Avatar, Box, Button, Paper, Tab, Tabs, Typography } from "@mui/material";
 import { Employee } from "../models/Employee";
 import { useCallback, useState } from "react";
+import Link from "next/link";
 
 const tabPanelValue = {
   basicInfo: "基本情報",
@@ -52,6 +54,13 @@ export function EmployeeDetails(prop: EmployeeDetailsProps) {
         alignItems="flex-start"
         gap={1}
       >
+        <Box mb={2}>
+          <Link href="/" style={{ textDecoration: "none" }}>
+            <Button variant="outlined" startIcon={<ArrowBackIcon />}>
+              検索画面に戻る
+            </Button>
+          </Link>
+        </Box>
         <Box
           display="flex"
           flexDirection="row"


### PR DESCRIPTION
### やったこと
タイトルの通り
![image](https://github.com/user-attachments/assets/9409531c-377c-4f57-9829-8db9d6ed108a)

- [x] `npm run lint` をパスした