### PR TITLE
ページごとにウィンドウタイトルを設定

### DIFF
--- a/frontend/src/app/employee/[id]/page.tsx
+++ b/frontend/src/app/employee/[id]/page.tsx
@@ -1,6 +1,11 @@
 import { EmployeeDetailsContainer } from "@/components/EmployeeDetailsContainer";
 import { GlobalContainer } from "@/components/GlobalContainer";
 import { Suspense } from 'react';
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "社員詳細",
+};
 
 export default function EmployeePage() {
   return (

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,10 @@
 import { SearchEmployees } from "../components/SearchEmployees";
 import { GlobalContainer } from "@/components/GlobalContainer";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "社員検索",
+};
 
 export default function Home() {
   return (


### PR DESCRIPTION
# 概要
ページごとにウィンドウタイトルが切り替わるように実装しました。

# 詳細
社員一覧ページ：「社員検索」
社員ごとのページ：「社員詳細」
※社員名も入れたいが、Task3と実装が被る分があるため、繋ぎ込みの別イシューを作成する。

# 確認

- [x] `npm run lint` をパスした