### PR TITLE
Task 3: ページごとにヘッダータイトルを作成

### DIFF
--- a/frontend/src/components/GlobalContainer.tsx
+++ b/frontend/src/components/GlobalContainer.tsx
@@ -1,15 +1,24 @@
+"use client";
+
 import { Container } from "@mui/material";
 import { VerticalSpacer } from "../components/VerticalSpacer";
 import { GlobalHeader } from "../components/GlobalHeader";
 import { GlobalFooter } from "../components/GlobalFooter";
+import { usePathname } from "next/navigation";
+import { getTitleByPathname } from "./utlils/GetTitleByPathname";
 
 export function GlobalContainer({ children }: { children?: React.ReactNode }) {
+  const pathname = usePathname();
+  const subtitle = getTitleByPathname(pathname);
   return (
     <Container
       sx={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}
     >
       <header>
-        <GlobalHeader title={"タレントマネジメントシステム"} />
+        <GlobalHeader
+          title={"タレントマネジメントシステム"}
+          subtitle={subtitle}
+        />
       </header>
 
       <VerticalSpacer height={32} />

--- a/frontend/src/components/GlobalHeader.tsx
+++ b/frontend/src/components/GlobalHeader.tsx
@@ -4,9 +4,10 @@ import Link from "next/link";
 
 export interface GlobalHeaderProps {
   title: string;
+  subtitle: string;
 }
 
-export function GlobalHeader({ title }: GlobalHeaderProps) {
+export function GlobalHeader({ title, subtitle }: GlobalHeaderProps) {
   return (
     <Box sx={{ flexGrow: 1 }}>
       <AppBar position="static">
@@ -22,7 +23,7 @@ export function GlobalHeader({ title }: GlobalHeaderProps) {
           </Link>
           <Link href="/">
             <Typography variant="h6" component="h1" sx={{ flexGrow: 1 }}>
-              {title}
+              {title} {subtitle}
             </Typography>
           </Link>
         </Toolbar>

--- a/frontend/src/components/utlils/GetTitleByPathname.ts
+++ b/frontend/src/components/utlils/GetTitleByPathname.ts
@@ -4,8 +4,15 @@ const pathTitleMap: { [key: string]: string } = {
 };
 
 export function getTitleByPathname(pathname: string): string {
-  const matchedEntry = Object.entries(pathTitleMap).find(([key]) =>
-    pathname.startsWith(key)
-  );
+  // 1. pathTitleMap を 配列(["/","社員検索"]) に変換
+  const entries = Object.entries(pathTitleMap);
+
+  // 2. キーの長さが長い順にソート
+  const sortedEntries = entries.sort((a, b) => b[0].length - a[0].length);
+
+  // 3. pathname にマッチする配列を探す
+  const matchedEntry = sortedEntries.find(([key]) => pathname.startsWith(key));
+
+  // 4. 見つかればタイトルを返す
   return matchedEntry ? matchedEntry[1] : "";
 }

--- a/frontend/src/components/utlils/GetTitleByPathname.ts
+++ b/frontend/src/components/utlils/GetTitleByPathname.ts
@@ -1,0 +1,11 @@
+const pathTitleMap: { [key: string]: string } = {
+  "/": "社員検索",
+  "/employee": "社員詳細",
+};
+
+export function getTitleByPathname(pathname: string): string {
+  const matchedEntry = Object.entries(pathTitleMap).find(([key]) =>
+    pathname.startsWith(key)
+  );
+  return matchedEntry ? matchedEntry[1] : "";
+}


### PR DESCRIPTION
#  概要
ページごとにウィンドウタイトルが切り替わるように実装しました。
![スクリーンショット 2025-07-05 112718](https://github.com/user-attachments/assets/7b717ff8-215e-4cde-9f9c-9b8828c09b35)
![スクリーンショット 2025-07-05 114521](https://github.com/user-attachments/assets/9270050a-675b-429a-800e-4a12ee21dc39)


#  詳細
・componentsフォルダ内にutilsフォルダを作成。

## components/utils/GetTitleByPathname.ts
パスから”タレントマネジメントシステム”に続くsubtitleを定義

## components/GlobalContainer.tsx
GlobalHeader.tsxにsubtitleを渡す

## components/GlobalHeader.tsx
propsにsubtitleの追加、表示

# 確認
✅ npm run lint をパスした