### PR TITLE
Task 22: WAF対応

### DIFF
--- a/cdk-ts/bin/cdk-ts.ts
+++ b/cdk-ts/bin/cdk-ts.ts
@@ -2,6 +2,7 @@
 import * as cdk from "aws-cdk-lib";
 import { AppStack } from "../lib/app-stack";
 import { PermanentResourcesStack } from "../lib/permanent-resources-stack";
+import { WafStack } from "../lib/waf-stack";
 import { withPrefix } from "../lib/commons";
 
 const app = new cdk.App();
@@ -10,8 +11,21 @@ const permanentResourcesStack = new PermanentResourcesStack(app, 'PermanentResou
   stackName: withPrefix('PermanentResourcesStack'),
 });
 
+const wafStack = new WafStack(app, "WafStack", {
+  stackName: withPrefix('WafStack'),
+  env: {
+    region: 'us-east-1'
+  },
+});
+
 const appStack = new AppStack(app, "AppStack", {
   stackName: withPrefix('ApplicationStack'),
+  webAclArn: wafStack.webAclArn,
+  crossRegionReferences: true,
+  env: {
+    // Cross stack/region references are only supported for stacks with an explicit region defined.
+    region: process.env.CDK_DEFAULT_REGION
+  },
 
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,

--- a/cdk-ts/lib/waf-stack.ts
+++ b/cdk-ts/lib/waf-stack.ts
@@ -71,11 +71,5 @@ export class WafStack extends cdk.Stack {
     });
 
     this.webAclArn = webAcl.attrArn;
-
-    new cdk.CfnOutput(this, "WebAclArn", {
-      value: webAcl.attrArn,
-      exportName: withPrefix("WebAclArn"),
-      description: "The ARN of the WAF WebACL for CloudFront",
-    });
   }
 }

--- a/cdk-ts/lib/waf-stack.ts
+++ b/cdk-ts/lib/waf-stack.ts
@@ -1,0 +1,81 @@
+import * as cdk from "aws-cdk-lib";
+import * as wafv2 from "aws-cdk-lib/aws-wafv2";
+import { Construct } from "constructs";
+import { withPrefix } from "./commons";
+
+export class WafStack extends cdk.Stack {
+  public readonly webAclArn: string;
+
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const webAcl = new wafv2.CfnWebACL(this, "WebACL", {
+      scope: "CLOUDFRONT",
+      defaultAction: { allow: {} },
+      name: withPrefix("WebACL"),
+      rules: [
+        {
+          name: "AWSManagedRulesCommonRuleSet",
+          priority: 1,
+          statement: {
+            managedRuleGroupStatement: {
+              vendorName: "AWS",
+              name: "AWSManagedRulesCommonRuleSet",
+            },
+          },
+          overrideAction: { none: {} },
+          visibilityConfig: {
+            sampledRequestsEnabled: true,
+            cloudWatchMetricsEnabled: true,
+            metricName: "CommonRuleSetMetric",
+          },
+        },
+        {
+          name: "AWSManagedRulesKnownBadInputsRuleSet",
+          priority: 2,
+          statement: {
+            managedRuleGroupStatement: {
+              vendorName: "AWS",
+              name: "AWSManagedRulesKnownBadInputsRuleSet",
+            },
+          },
+          overrideAction: { none: {} },
+          visibilityConfig: {
+            sampledRequestsEnabled: true,
+            cloudWatchMetricsEnabled: true,
+            metricName: "KnownBadInputsRuleSetMetric",
+          },
+        },
+        {
+          name: "AWSManagedRulesSQLiRuleSet",
+          priority: 3,
+          statement: {
+            managedRuleGroupStatement: {
+              vendorName: "AWS",
+              name: "AWSManagedRulesSQLiRuleSet",
+            },
+          },
+          overrideAction: { none: {} },
+          visibilityConfig: {
+            sampledRequestsEnabled: true,
+            cloudWatchMetricsEnabled: true,
+            metricName: "SQLiRuleSetMetric",
+          },
+        },
+      ],
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "WebACL",
+      },
+    });
+
+    this.webAclArn = webAcl.attrArn;
+
+    new cdk.CfnOutput(this, "WebAclArn", {
+      value: webAcl.attrArn,
+      exportName: withPrefix("WebAclArn"),
+      description: "The ARN of the WAF WebACL for CloudFront",
+    });
+  }
+}


### PR DESCRIPTION
### やったこと
AWS WAFを導入して、怪しいリクエストが来ないようにした

適応したマネージドルール

- [コアルールセット (CRS) マネージドルールグループ](https://docs.aws.amazon.com/ja_jp/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs)
- [既知の不正な入力マネージドルールグループ](https://docs.aws.amazon.com/ja_jp/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs)
- [SQL database managed rule group](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db)