### PR TITLE
Task 103: 画像最適化機能の無効化

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -11,7 +11,10 @@ const nextConfig: NextConfig = {
       },
     ];
   },
-  output: 'export',
+  output: "export",
+  images: {
+    unoptimized: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
経緯：next.config.tsの変更によって静的エクスポートになった→画像最適化機能が邪魔をしてデフォルトのImagタグが動かなくなってしまいました。

解決法：unoptimized: true,で最適化を無効化して緩めました。
